### PR TITLE
Display all source relations

### DIFF
--- a/trunk/mermeid/forms/mei/details-source.xml
+++ b/trunk/mermeid/forms/mei/details-source.xml
@@ -157,15 +157,17 @@
                         <h:legend>Relations <h:a class="help">&#160;?<h:span class="comment">Defines
                                     relations between this source and other sources, versions (FRBR:
                                     "expressions") of this work, other works etc.<h:br/> Currently
-                                    only two relations have a visible effect in MerMEId: the
+                                    two relations are handled in a special way in MerMEId's HTML preview: the
                                     relation "is reproduction of" pointing to another source marks
                                     this source as being a reprint of the other source; the "is
                                     embodiment of" relation pointing to an expression (version) of
                                     the works is used to specify which particular version of the
                                     work is embodied by this source.<h:br/>
+                                    All other relations will be displayed as [relation]: [label]. 
+                                    If no label is specified, MerMEId displays the xml:id of the target instead. 
                                     <h:br/>Depending on the encoding pratice of your project,
                                     relations may or may not be defined mutually, i.e. the opposite
-                                    relation may be defined on the target.<h:br/> The list is based
+                                    relation may be defined on the target.<h:br/> The list of relations is based
                                     on FRBR relations (see
                                     http://www.ifla.org/files/cataloguing/frbr/frbr_2008.pdf).
                                 </h:span></h:a></h:legend>
@@ -189,20 +191,29 @@
                                             <xf:itemset
                                                 nodeset="instance('data-instance')//m:source/@xml:id[.!=$this_id] | instance('data-instance')//m:expression/@xml:id">
                                                 <xf:label>
-                                                  <xf:output
-                                                  value="concat(../m:titleStmt/m:title[1],' (',.,')')"
-                                                  />
+                                                  <xf:output value="concat(../m:titleStmt/m:title[1],' (',.,')')"/>
                                                 </xf:label>
                                                 <xf:value ref="concat('#',.)"/>
                                             </xf:itemset>
+                                            <xf:action ev:event="xforms-value-changed">
+                                                <!-- insert target label if empty -->
+                                                <xf:action if="../@label=''">
+                                                    <xf:var name="target" select="translate(../@target,'#','')"/>
+                                                    <xf:setvalue ref="../@label" value="instance('data-instance')//*[@xml:id=$target]/m:titleStmt/m:title[1]"/>
+                                                </xf:action>
+                                            </xf:action>
                                         </xf:select1>
                                     </h:td>
-                                    <!--<h:td>
+                                    <h:td>
                                             <xf:input ref="@label" class="long">
-                                            <xf:label> Link label <h:a class="help">&#160;?<h:span class="comment">The text to be 
-                                            displayed as the link text</h:span></h:a></xf:label>
+                                            <xf:label> Target label <h:a class="help">&#160;?<h:span class="comment">The text to be 
+                                              displayed as the target of the relation (for instance, the title or label of the source referred to).<h:br/>
+                                              By default, MerMEId inserts the title of the element referred to (if any), but any text may be entered.<h:br/>
+                                              Please note that MerMEId displays labels containing a colon (:) in a special way: In
+                                              that case, the text before the colon is displayed as the relation label instead of the
+                                              standard description af the relation.</h:span></h:a></xf:label>
                                             </xf:input>
-                                            </h:td>-->
+                                            </h:td>
                                     <h:td style="vertical-align:top; white-space:nowrap;">
                                         <h:span class="editmenu">
                                             <dcm:element-buttons

--- a/trunk/mermeid/forms/mei/edit-form-footer.xml
+++ b/trunk/mermeid/forms/mei/edit-form-footer.xml
@@ -38,8 +38,8 @@
         <div class="about_main">
             
             <p style="text-align:center">
-                Rev. <xf:output value="substring-before(substring-after('$Revision: 1271 $','Revision: '),'$')"/>
-                (<xf:output value="substring-before(substring-after('$Date:: 2017-10-13 #$','Date:: '),' #$')"/>)
+                Rev. <xf:output value="substring-before(substring-after('$Revision: 1272 $','Revision: '),'$')"/>
+                (<xf:output value="substring-before(substring-after('$Date:: 2017-10-24 #$','Date:: '),' #$')"/>)
             </p>
             <p style=""> </p>
 

--- a/trunk/xqueries/style/mei_to_html.xsl
+++ b/trunk/xqueries/style/mei_to_html.xsl
@@ -573,6 +573,34 @@
 		</xsl:if>
 	</xsl:template>
 	
+	<xsl:template match="m:relationList" mode="plain_relation_list">
+		<!-- Compact list of relations for use at sub-levels such as source relations -->
+		<xsl:for-each select="m:relation">
+			<xsl:choose>
+				<xsl:when test="contains(@label,':')">
+					<xsl:value-of select="@label"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:call-template name="translate_relation">
+						<xsl:with-param name="label" select="@label"/>
+						<xsl:with-param name="rel" select="@rel"/>
+					</xsl:call-template>
+					<xsl:choose>
+						<xsl:when test="@label!=''">
+							<xsl:value-of select="@label"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="@target"/>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:otherwise>
+			</xsl:choose>
+			<xsl:text>.</xsl:text>
+			<xsl:if test="position()!=last()"><br/></xsl:if>
+		</xsl:for-each>
+		
+	</xsl:template>
+	
 	<xsl:template match="m:relation" mode="relation_link">
 		<!-- internal cross references between works in the catalogue are treated in a special way -->
 		<xsl:variable name="mermeid_crossref">
@@ -660,25 +688,29 @@
 	<xsl:template name="translate_relation">
 		<xsl:param name="rel"/>
 		<xsl:param name="label"/>
-		<xsl:choose>
-			<xsl:when test="$rel='hasReproduction'">
-				<xsl:choose>
-					<xsl:when test="contains($label,'Edition')"><xsl:value-of select="$l/edition"/>:</xsl:when>
-					<xsl:otherwise><xsl:value-of select="$l/hasReproduction"/>:</xsl:otherwise>
-				</xsl:choose>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:choose>
-					<xsl:when test="$l/*[name()=$rel]">
-						<xsl:value-of select="$l/*[name()=$rel][1]"/>:
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:value-of select="$rel"/>:
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:otherwise>
-		</xsl:choose>
-
+		<xsl:variable name="display_label">
+			<xsl:choose>
+				<xsl:when test="$rel='hasReproduction'">
+					<xsl:choose>
+						<xsl:when test="contains($label,'Edition')"><xsl:value-of select="$l/edition"/>:</xsl:when>
+						<xsl:otherwise><xsl:value-of select="$l/hasReproduction"/></xsl:otherwise>
+					</xsl:choose>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:choose>
+						<xsl:when test="$l/*[name()=$rel]">
+							<xsl:value-of select="$l/*[name()=$rel][1]"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="$rel"/>
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:variable>
+		<xsl:call-template name="capitalize">
+			<xsl:with-param name="str" select="concat($display_label,': ')"></xsl:with-param>
+		</xsl:call-template>
 	</xsl:template>
 
 	<xsl:template match="m:expression" mode="top_level">
@@ -1917,6 +1949,19 @@
 					</xsl:choose>
 				</div>
 			</xsl:for-each>
+			
+			
+			<!-- List the source's relations except those visualized otherwise: reproductions (=reprint) and the version embodied -->
+			<xsl:variable name="collect_source_relations">
+				<relationList xmlns="http://www.music-encoding.org/ns/mei">
+					<xsl:for-each select="m:relationList/m:relation[@rel!='isEmbodimentOf' and @rel!='isReproductionOf' and @target!='']">
+						<xsl:copy-of select="."/>
+					</xsl:for-each>
+				</relationList>
+			</xsl:variable>
+			<xsl:variable name="source_relations" select="exsl:node-set($collect_source_relations)"/>
+			<xsl:apply-templates select="$source_relations" mode="plain_relation_list"/>
+			
 
 			<!-- List exemplars (items) last if there is more than one or if it does have a heading of its own. 
 	   Otherwise, this is assumed to be a manuscript with some information given at item level, 


### PR DESCRIPTION
All relations at source levels are now listed (except those having a special effect: reproduction of (interpreted as reprints) and embodiment of (lists the source under a specific version)